### PR TITLE
Migrate workflows to upstream action refs, SHA-pinned (ENG-90)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4.9.1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Part of ENG-90.

Both refs were already upstream (never forked) but tag-pinned; now SHA-pinned. Also bumps checkout from v3 to v6.0.2 to clear the Node 20 deprecation warning.

- actions/checkout@de0fac2e... (v6.0.2)
- actions/setup-python@7f4fc3e2... (v4.9.1)